### PR TITLE
Add entry file for sub base dir

### DIFF
--- a/bin-src/lib/getDependentStoryFiles.test.ts
+++ b/bin-src/lib/getDependentStoryFiles.test.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import * as path from 'path';
 
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
 import * as git from '../git/git';
@@ -71,6 +72,32 @@ describe('getDependentStoryFiles', () => {
     const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(res).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
+    });
+  });
+
+  it('detects direct changes to CSF files, 6.4 subdirectory', async () => {
+    const subDirectory = 'subdirectory';
+    const changedFiles = [`${subDirectory}/src/foo.stories.js`];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: 'generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ storybookBaseDir: '' });
+    const originRelative = path.posix.relative;
+    jest.mock('path');
+    path.posix.relative = jest.fn().mockImplementationOnce(() => subDirectory);
+    const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    path.posix.relative = originRelative;
+    expect(res).toEqual({
+      './src/foo.stories.js': [`${subDirectory}/src/foo.stories.js`],
     });
   });
 

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -81,6 +81,8 @@ export async function getDependentStoryFiles(
     `${storybookDir}/generated-stories-entry.js`,
     // v6 store with root as config dir (or SB 6.4)
     `generated-stories-entry.js`,
+    // v6 store with subdirectory (SB 6.4)
+    `${baseDir}/generated-stories-entry.js`,
     // v7 store (SB >= 6.4)
     `storybook-stories.js`,
   ];


### PR DESCRIPTION
## Current status

* I'm developing in Monorepo
* I'm managing Storybook in a sub directory of my git root directory.

example

```
repo/
├── .git
└── sub
    ├── .storybook
    ├── assets
    │   └── js
    │       └── components
    │           └── Button
    │               ├── index.stories.tsx
    │               └── index.tsx
    ├── package.json
    └── yarn.lock
```

## Problem

* When I run TurboSnap on v6.4.3, I get the following error message
  * ```
    Did not find any CSF globs in preview-stats.json
    ```
* In the structure of this sub directory, it doesn't seem to be able to find the dependent story files well

## Solution

* When I looked at the output stats file, I found that the entry file was in the format `${baseDir}/generated-stories-entry.js`, so I fixed it that way

## Notes

* I'm creating this PR to show the differences
* I'm actually branching from the `v6.4.3` tag.